### PR TITLE
Sort competitions, remove unnecesarry comments

### DIFF
--- a/src/app/Advanced-Dashboard/AdvancedDashboard.tsx
+++ b/src/app/Advanced-Dashboard/AdvancedDashboard.tsx
@@ -1,4 +1,3 @@
-// Server component
 import { CompetitionType, Users } from "../Types/solve";
 import styles from "./AdvancedDashboard.module.css";
 import Backup from "./Backup";

--- a/src/app/Advanced-Dashboard/page.tsx
+++ b/src/app/Advanced-Dashboard/page.tsx
@@ -1,4 +1,3 @@
-// Server component
 import AdvancedDashboard from "./AdvancedDashboard";
 import { getUsers } from "../utils/users";
 import { getCompetitions } from "../utils/competitions";

--- a/src/app/Competitions/Competition.tsx
+++ b/src/app/Competitions/Competition.tsx
@@ -1,4 +1,3 @@
-// Server component
 import { AllowedEvents, CompetitionResultType } from "../Types/solve";
 import CompetitionEvent from "./CompetitionEvent";
 import competitionStyles from "./Competitions.module.css";

--- a/src/app/Competitions/CompetitionEvent.tsx
+++ b/src/app/Competitions/CompetitionEvent.tsx
@@ -1,4 +1,3 @@
-// Server component
 import EventResults from "./EventResults";
 import { Result } from "../Types/solve";
 

--- a/src/app/Competitions/Competitions.tsx
+++ b/src/app/Competitions/Competitions.tsx
@@ -1,4 +1,3 @@
-// Server component
 import { CompetitionResultsType } from "../Types/solve";
 import Competition from "./Competition";
 
@@ -9,22 +8,26 @@ type Props = {
         status: number;
     };
 };
+
 export default async function Competitions(props: Props) {
     const competitions = props.competitions.parsed;
 
-    const competitionNames = Object.keys(props.competitions.parsed);
+    // Convert competitions object to array and sort by date
+    const sortedCompetitions = Object.entries(competitions).sort((a, b) => {
+        const dateA = new Date(a[1].date);
+        const dateB = new Date(b[1].date);
+        return dateB.getTime() - dateA.getTime(); // Newest first
+    });
+
     return (
         <main>
-            {competitionNames.map((compName, index) => {
-                const competition = competitions[compName];
-                return (
-                    <Competition
-                        competitionName={compName}
-                        competition={competition}
-                        key={index}
-                    />
-                );
-            })}
+            {sortedCompetitions.map(([compName, competition], index) => (
+                <Competition
+                    competitionName={compName}
+                    competition={competition}
+                    key={index}
+                />
+            ))}
         </main>
     );
 }

--- a/src/app/Competitions/EventResults.tsx
+++ b/src/app/Competitions/EventResults.tsx
@@ -1,4 +1,3 @@
-// Server component
 import Group from "./Group";
 import CompetitionStyles from "./Competitions.module.css";
 import { Result } from "../Types/solve";

--- a/src/app/Competitions/page.tsx
+++ b/src/app/Competitions/page.tsx
@@ -1,4 +1,3 @@
-// Server component
 import Competitions from "./Competitions";
 import { Metadata } from "next";
 import { getResults } from "../utils/competitions";

--- a/src/app/Register/page.tsx
+++ b/src/app/Register/page.tsx
@@ -1,4 +1,3 @@
-// Server component
 import { Metadata } from "next";
 import RegisterPage from "./RegisterPage";
 import ProtectedRoute from "../components/Common/ProtectedRoute";


### PR DESCRIPTION
This PR is going to:
- Sort competitions on `/Competitions` page
- Remove `// Server component` comments